### PR TITLE
1035141: Removed syncfusion word from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FTP service for the file manager component
 
-This repository contains the ASP.NET Core file transfer protocol file system providers for the Syncfusion File Manager component.
+This repository contains the ASP.NET Core file transfer protocol file system providers for the File Manager component.
 
 ## Key Features
 


### PR DESCRIPTION
### Description :

Removed the Syncfusion name in Readme

Reference PR: [PR Link](https://github.com/SyncfusionExamples/typescript-pdf-viewer-examples/pull/44)